### PR TITLE
fix: Custom prefix-list conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module "onboard_aws_vpc" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_vpc"></a> [aws\_vpc](#input\_aws\_vpc) | Name of the AWS VPC to be onboarded; Also used for AWS Connector name | `string` | `""` | no |
 | <a name="input_billing_tag"></a> [billing\_tag](#input\_billing\_tag) | Alkira billing tag applied to connector | `string` | n/a | yes |
-| <a name="input_credential"></a> [credential](#input\_credential) | Alkira credentail used for AWS authentication | `string` | n/a | yes |
+| <a name="input_credential"></a> [credential](#input\_credential) | Alkira credential used for AWS authentication | `string` | n/a | yes |
 | <a name="input_custom_prefixes"></a> [custom\_prefixes](#input\_custom\_prefixes) | List of custom prefix-lists for routing (prefix-lists must already exist in Alkira CSX) | `list(string)` | `[]` | no |
 | <a name="input_cxp"></a> [cxp](#input\_cxp) | Alkira CXP to create connector in | `string` | n/a | yes |
 | <a name="input_group"></a> [group](#input\_group) | Alkira Group to add connector to | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -30,8 +30,8 @@ module "onboard_aws_vpc" {
   count = length(var.aws_vpc) > 0 ? 1 : 0
 
   # Some conditions
-  is_subnet       = length(var.onboard_subnets) > 0 ? true : false
-  onboard_subnets = var.onboard_subnets
+  is_subnet = length(var.onboard_subnets) > 0 ? true : false
+  is_custom = length(var.custom_prefixes) > 0 ? true : false
 
   # AWS values
   aws_vpc = var.aws_vpc
@@ -39,6 +39,7 @@ module "onboard_aws_vpc" {
   # Alkira values
   cxp             = var.cxp
   size            = var.size
+  onboard_subnets = var.onboard_subnets
   custom_prefixes = var.custom_prefixes
   group           = data.alkira_group.group.id
   segment_id      = data.alkira_segment.segment.id

--- a/modules/aws-vpc/README.md
+++ b/modules/aws-vpc/README.md
@@ -39,10 +39,11 @@ No modules.
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS account ID that owns or contains calling entity | `string` | `""` | no |
 | <a name="input_aws_vpc"></a> [aws\_vpc](#input\_aws\_vpc) | Name of the AWS VPC to be onboarded; Also used for AWS Connector name | `string` | n/a | yes |
 | <a name="input_billing_tag_id"></a> [billing\_tag\_id](#input\_billing\_tag\_id) | ID of Alkira billing tag applied to connector | `string` | n/a | yes |
-| <a name="input_credential_id"></a> [credential\_id](#input\_credential\_id) | ID of Alkira credentail used for AWS authentication | `string` | n/a | yes |
+| <a name="input_credential_id"></a> [credential\_id](#input\_credential\_id) | ID of Alkira credential used for AWS authentication | `string` | n/a | yes |
 | <a name="input_custom_prefixes"></a> [custom\_prefixes](#input\_custom\_prefixes) | List of custom prefix-lists for routing (prefix-lists must already exist in Alkira CSX) | `list(string)` | `[]` | no |
 | <a name="input_cxp"></a> [cxp](#input\_cxp) | Alkira CXP to create connector in | `string` | n/a | yes |
 | <a name="input_group"></a> [group](#input\_group) | Name of Alkira group to add connector to | `string` | n/a | yes |
+| <a name="input_is_custom"></a> [is\_custom](#input\_is\_custom) | Controls if custom prefixes are used for routing from cloud network to CXP; This value automatically changes to 'true' if custom\_prefixes list is set | `bool` | `false` | no |
 | <a name="input_is_subnet"></a> [is\_subnet](#input\_is\_subnet) | Controls if subnet gets onboarded in lieu of entire cloud network; This value automatically changes to 'true' if onboard\_subnets list is set | `bool` | `false` | no |
 | <a name="input_onboard_subnets"></a> [onboard\_subnets](#input\_onboard\_subnets) | List of subnet names to onboard in lieu of entire network | `list(string)` | `[]` | no |
 | <a name="input_segment_id"></a> [segment\_id](#input\_segment\_id) | ID of Alkira segment to add connector to | `string` | n/a | yes |

--- a/modules/aws-vpc/main.tf
+++ b/modules/aws-vpc/main.tf
@@ -92,7 +92,7 @@ resource "alkira_connector_aws_vpc" "connector" {
     # Does custom bool exist? If not, default
     content {
       id              = data.aws_vpc.selected.main_route_table_id
-      options         = var.is_subnet ? "ADVERTISE_CUSTOM_PREFIX" : "ADVERTISE_DEFAULT_ROUTE"
+      options         = var.is_custom ? "ADVERTISE_CUSTOM_PREFIX" : "ADVERTISE_DEFAULT_ROUTE"
       prefix_list_ids = try([vpc_route_table.value.id])
     }
   }

--- a/modules/aws-vpc/variables.tf
+++ b/modules/aws-vpc/variables.tf
@@ -11,6 +11,12 @@ variable "is_subnet" {
   default     = false
 }
 
+variable "is_custom" {
+  description = "Controls if custom prefixes are used for routing from cloud network to CXP; This value automatically changes to 'true' if custom_prefixes list is set"
+  type        = bool
+  default     = false
+}
+
 variable "aws_vpc" {
   description = "Name of the AWS VPC to be onboarded; Also used for AWS Connector name"
   type        = string
@@ -33,7 +39,7 @@ variable "billing_tag_id" {
 }
 
 variable "credential_id" {
-  description = "ID of Alkira credentail used for AWS authentication"
+  description = "ID of Alkira credential used for AWS authentication"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "billing_tag" {
 }
 
 variable "credential" {
-  description = "Alkira credentail used for AWS authentication"
+  description = "Alkira credential used for AWS authentication"
   type        = string
 }
 


### PR DESCRIPTION
Fix custom prefix-list conditional logic -> If custom_prefix variable contains values, automatically use ADVERTISE_CUSTOM_PREFIX -> else, ADVERTISE_DEFAULT_ROUTE.