### PR TITLE
refactor: Add optional azure_subscription_id field for azure connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ module "onboard_aws_vpc" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.0 |
+| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.0 |
+| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.4 |
 
 ## Modules
 
@@ -66,6 +66,7 @@ module "onboard_aws_vpc" {
 | <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Name of the Azure VNet to be onboarded; Also used for Azure Connector name | `string` | `""` | no |
 | <a name="input_segment"></a> [segment](#input\_segment) | Alkira segment to add connector to | `string` | n/a | yes |
 | <a name="input_size"></a> [size](#input\_size) | Alkira connector size | `string` | `"SMALL"` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ module "onboard_azure_vnet" {
   count = length(var.azure_vnet) > 0 ? 1 : 0
 
   # Some conditions
+  is_sub    = length(var.subscription_id) > 0 ? true : false
   is_custom = length(var.custom_prefixes) > 0 ? true : false
 
   # Azure values
@@ -68,6 +69,7 @@ module "onboard_azure_vnet" {
   # Alkira values
   cxp             = var.cxp
   size            = var.size
+  subscription_id = var.subscription_id
   custom_prefixes = var.custom_prefixes
   group           = data.alkira_group.group.name
   segment_id      = data.alkira_segment.segment.id

--- a/modules/aws-vpc/README.md
+++ b/modules/aws-vpc/README.md
@@ -6,14 +6,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.0 |
+| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.4 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.0 |
+| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.4 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63 |
 
 ## Modules

--- a/modules/aws-vpc/versions.tf
+++ b/modules/aws-vpc/versions.tf
@@ -5,7 +5,7 @@ terraform {
 
     alkira = {
       source  = "alkiranet/alkira"
-      version = ">= 0.7.0"
+      version = ">= 0.7.4"
     }
 
     aws = {

--- a/modules/azure-vnet/README.md
+++ b/modules/azure-vnet/README.md
@@ -6,14 +6,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29 |
-| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.0 |
+| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 2.46.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.0 |
+| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 2.46.0 |
 
 ## Modules
@@ -39,9 +39,11 @@ No modules.
 | <a name="input_cxp"></a> [cxp](#input\_cxp) | Alkira CXP to create connector in | `string` | n/a | yes |
 | <a name="input_group"></a> [group](#input\_group) | Name of Alkira group to add connector to | `string` | n/a | yes |
 | <a name="input_is_custom"></a> [is\_custom](#input\_is\_custom) | Controls if custom prefixes are used for routing from cloud network to CXP; This value automatically changes to 'true' if custom\_prefixes list is set | `bool` | `false` | no |
+| <a name="input_is_sub"></a> [is\_sub](#input\_is\_sub) | Controls if subscription ID is passed in or referenced in Alkira credential; Default uses Alkira credential | `bool` | `false` | no |
 | <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Name of Azure Resource Group | `string` | n/a | yes |
 | <a name="input_segment_id"></a> [segment\_id](#input\_segment\_id) | ID of Alkira segment to add connector to | `string` | n/a | yes |
 | <a name="input_size"></a> [size](#input\_size) | Size of Alkira connector; SMALL, MEDIUM, LARGE | `string` | `"SMALL"` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/azure-vnet/main.tf
+++ b/modules/azure-vnet/main.tf
@@ -19,9 +19,10 @@ data "alkira_policy_prefix_list" "prefix" {
 resource "alkira_connector_azure_vnet" "connector" {
 
   # Azure values
-  name          = var.azure_vnet
-  azure_vnet_id = data.azurerm_virtual_network.azure_vnet.id
-  azure_region  = data.azurerm_virtual_network.azure_vnet.location
+  name                  = var.azure_vnet
+  azure_vnet_id         = data.azurerm_virtual_network.azure_vnet.id
+  azure_region          = data.azurerm_virtual_network.azure_vnet.location
+  azure_subscription_id = var.is_sub ? var.subscription_id : null
 
   # CXP values
   cxp             = var.cxp

--- a/modules/azure-vnet/variables.tf
+++ b/modules/azure-vnet/variables.tf
@@ -4,6 +4,18 @@ variable "is_custom" {
   default     = false
 }
 
+variable "is_sub" {
+  description = "Controls if subscription ID is passed in or referenced in Alkira credential; Default uses Alkira credential"
+  type        = bool
+  default     = false
+}
+
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  default     = ""
+}
+
 variable "resource_group" {
   description = "Name of Azure Resource Group"
   type        = string

--- a/modules/azure-vnet/versions.tf
+++ b/modules/azure-vnet/versions.tf
@@ -5,7 +5,7 @@ terraform {
 
     alkira = {
       source  = "alkiranet/alkira"
-      version = ">= 0.7.0"
+      version = ">= 0.7.4"
     }
 
     azurerm = {

--- a/modules/gcp-vpc/README.md
+++ b/modules/gcp-vpc/README.md
@@ -6,14 +6,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.29 |
-| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.0 |
+| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.7.4 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | < 5.0, >= 2.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.0 |
+| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.7.4 |
 | <a name="provider_google"></a> [google](#provider\_google) | < 5.0, >= 2.12 |
 
 ## Modules

--- a/modules/gcp-vpc/versions.tf
+++ b/modules/gcp-vpc/versions.tf
@@ -5,7 +5,7 @@ terraform {
 
     alkira = {
       source  = "alkiranet/alkira"
-      version = ">= 0.7.0"
+      version = ">= 0.7.4"
     }
 
     google = {

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "project" {
   default     = ""
 }
 
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+  default     = ""
+}
+
 variable "resource_group" {
   description = "Name of the Azure VNet to be onboarded; Also used for Azure Connector name"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
 
     alkira = {
       source  = "alkiranet/alkira"
-      version = ">= 0.7.0"
+      version = ">= 0.7.4"
     }
 
   }


### PR DESCRIPTION
[The following update](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/guides/release-notes-v0.7.4) adds the _azure_subscription_id_ field to azure connector resource (as optional) if it is not provided in azure credential.